### PR TITLE
#3 その他のページにheaderNavBar,footerコンポーネントを適応させる

### DIFF
--- a/wcdi-web/pages/about.vue
+++ b/wcdi-web/pages/about.vue
@@ -1,5 +1,6 @@
 <template>
   <div>
+    <HeaderNavBar />
     <Header pageTitle="About Us"></Header>
     <div class="Container">
       <h2 class="title">ITRCについて</h2>
@@ -64,16 +65,18 @@
     <p class="backtotop">Top→</p>
     <!-- Topボタンはまだただのカカシ -->
     </div>
-    <Footer></Footer>
+    <Footer />
   </div>
 </template>
 
 <script>
-  import Header from '../components/Header';
-  import Footer from '../components/Footer';
+  import HeaderNavBar from '~/components/HeaderNavBar';
+  import Header from '~/components/Header';
+  import Footer from '~/components/Footer';
   export default {
     name: "about",
     components: {
+      HeaderNavBar,
       Header,
       Footer
     }

--- a/wcdi-web/pages/activity.vue
+++ b/wcdi-web/pages/activity.vue
@@ -1,5 +1,6 @@
 <template>
   <div>
+    <HeaderNavBar />
     <Header pageTitle="活動ログ"></Header>
     <div class="Container">
       <h2 class="title">最近の活動</h2>
@@ -48,15 +49,20 @@
       </div>
       <p class="backtotop">Top→</p>
     </div>
+    <Footer />
   </div>
 </template>
 
 <script>
-  import Header from '../components/Header';
+  import HeaderNavBar from '~/components/HeaderNavBar';
+  import Header from '~/components/Header';
+  import Footer from '~/components/Footer';
     export default {
         name: "activity",
         components: {
-          Header
+          HeaderNavBar,
+          Header,
+          Footer
         }
     }
 </script>

--- a/wcdi-web/pages/member.vue
+++ b/wcdi-web/pages/member.vue
@@ -1,5 +1,6 @@
 <template>
   <div>
+    <HeaderNavBar />
     <Header pageTitle="メンバー"></Header>
     <div class="Container">
       <h2 class="title">メンバー一覧</h2>
@@ -25,15 +26,20 @@
       </div>
       <p class="backtotop">Top→</p>
     </div>
+    <Footer />
   </div>
 </template>
 
 <script>
-  import Header from '../components/Header';
+  import HeaderNavBar from '~/components/HeaderNavBar';
+  import Header from '~/components/Header';
+  import Footer from '~/components/Footer';
   export default {
     name: "member",
     components: {
-      Header
+      HeaderNavBar,
+      Header,
+      Footer
     }
   }
 </script>

--- a/wcdi-web/pages/news/comicmarket98.vue
+++ b/wcdi-web/pages/news/comicmarket98.vue
@@ -1,5 +1,6 @@
 <template>
   <div>
+    <HeaderNavBar />
     <Header pageTitle="コミックマーケット98にサークル参加します"></Header>
     <div class="Container">
       <h2 class="title">概要</h2>
@@ -38,15 +39,20 @@
       </div>
       <p class="backtotop">Top→</p>
     </div>
+    <Footer />
   </div>
 </template>
 
 <script>
-  import Header from '@/components/Header';
+  import HeaderNavBar from '~/components/HeaderNavBar';
+  import Header from '~/components/Header';
+  import Footer from '~/components/Footer';
   export default {
     name: "information",
     components: {
-      Header
+      HeaderNavBar,
+      Header,
+      Footer
     }
   }
 </script>


### PR DESCRIPTION
その他のページにheaderNavBar,footerが適応されてないので改修しました。

## 詳細

### headerNavBarコンポーネントが適応したページ

- about
- activity
- news/comicmarket98
- member

### footerコンポーネントが適応したページ

- activity
- news/comicmarket98
- member