### PR TITLE
Fix: Responsive layout collapse #5

### DIFF
--- a/wcdi-web/components/Header.vue
+++ b/wcdi-web/components/Header.vue
@@ -1,9 +1,9 @@
 <template>
   <section class="top-image top-section">
     <div class="box">
-    
+
       <p>{{ pageTitle }}</p>
-      
+
     </div>
 </section>
 </template>
@@ -29,7 +29,8 @@
   justify-content: space-around;
 }
 .box{
-  padding: 12rem;
+  padding-top: 12rem;
+  padding-bottom: 12rem;
 }
 
 .box p {

--- a/wcdi-web/components/TheExplanationSection.vue
+++ b/wcdi-web/components/TheExplanationSection.vue
@@ -10,7 +10,7 @@
           <p class="text">情報技術研究部は日本工学院八王子専門学校にて<br>活動中のサークルです</p>
           <p class="text">それぞれ<strong>高い目標</strong>を持つ部員が集まり活動しています</p>
           <p class="text">定期的にもくもく会, LT大会, コンテストの参加を行い<br>日々研鑽を重ねています</p>
-         
+
           <div class="AboutUsButtonSize">
             <a id="ButtonText" href="./about">
               <div class="AboutUsButton">about us</div>
@@ -44,14 +44,11 @@
   }
 
   .AboutUsButtonSize {
-  display: flex;
-  justify-content: center;
-  font-size: 1.6em;
-  padding: 0 2em;
-  margin-top: 4rem;
-  margin-left: 65%;
-  margin-right: 25%;
-}
+    display: flex;
+    font-size: 1.6em;
+    margin-top: 4rem;
+    margin-left: 70%;
+  }
 .AboutUsButton {
   background: #208cc2;
   color: #fff;
@@ -102,6 +99,11 @@
   @media screen and (max-width: 784px) {
     .text  br {
       display: inline-block;
+    }
+    .AboutUsButtonSize {
+      margin-left: auto;
+      margin-right: auto;
+      justify-content: center;
     }
   }
 </style>


### PR DESCRIPTION
レスポンシブ時にレイアウトが崩れるバグを修正。  
`components/TheExplanationSection.vue` のAboutUsボタンが原因のため、AboutUsボタンをレスポンシブ対応させ修正させました。
その他のページでは`Header.vue`が原因のため、タイトルのpaddingを修正しました