### PR TITLE
fix: HeaderNavBar.vue #10,#11

### DIFF
--- a/wcdi-web/components/HeaderNavBar.vue
+++ b/wcdi-web/components/HeaderNavBar.vue
@@ -1,6 +1,5 @@
 <template>
   <header class="header-background sp-container">
-    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
     <nav>
       <ul class="header-ul">
         <li class="header-li">
@@ -63,43 +62,16 @@
 
 <script>
 // 現状ここは無視でいいよ
-export default {};
+export default {
+  head: {
+    link: [
+      { rel: 'stylesheet', href: 'https://fonts.googleapis.com/icon?family=Material+Icons' }
+    ]
+  }
+};
 </script>
 
 <style scoped>
-
-  @font-face {
-  font-family: "Material Icons";
-  font-style: normal;
-  font-weight: 400;
-  src: url(https://example.com/MaterialIcons-Regular.eot); /* For IE6-8 */
-  src: local("Material Icons"), local("MaterialIcons-Regular"),
-    url(https://example.com/MaterialIcons-Regular.woff2) format("woff2"),
-    url(https://example.com/MaterialIcons-Regular.woff) format("woff"),
-    url(https://example.com/MaterialIcons-Regular.ttf) format("truetype");
-}
-
-.material-icons {
-  font-family: "Material Icons";
-  font-weight: normal;
-  font-style: normal;
-  font-size: 24px; /* Preferred icon size */
-  display: inline-block;
-  line-height: 1;
-  text-transform: none;
-  letter-spacing: normal;
-  word-wrap: normal;
-  white-space: nowrap;
-  direction: ltr;
-  /* Support for all WebKit browsers. */
-  -webkit-font-smoothing: antialiased;
-  /* Support for Safari and Chrome. */
-  text-rendering: optimizeLegibility;
-  /* Support for Firefox. */
-  -moz-osx-font-smoothing: grayscale;
-  /* Support for IE. */
-  font-feature-settings: "liga";
-}
 
 .header-background {
   height: 81px;


### PR DESCRIPTION
マテリアルアイコンの実装方法を変更しました。
確認お願いします。

## 詳細

- アドバイスを貰い、scriptにheadオブジェクトでlinkを設定する方法で実装しました。
- headerに書き込んでいたリンクを削除しました。
- cssに書いてあった実装出来ていないコードを削除しました。